### PR TITLE
[Proposal] Docs: A new way to contribute code to Pax.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,6 @@ Please name your branch as follows:
 ### 3.3 Pull Requests
 
 #### 3.3.1 Title
-
 Your title should be short and concise. It should be in the format:
 `<type>: <desc>`
 where `<type>` is one of the following:
@@ -42,7 +41,6 @@ where `<type>` is one of the following:
 and `<desc>` is a short description of the changes made.
 
 #### 3.3.2 Description
-
 Your description is where you can go into more detail about your changes.
 Please include _at least_ the following:
 - What you changed
@@ -52,7 +50,6 @@ If your PR is related to an issue, please include the issue number in the descri
 If it solves the issue, please include `Closes #<issue-number>` in the description. This will automatically close the issue when the PR is merged.
 
 #### 3.3.3 Labels
-
 Each PR MUST have at least one label. The following labels are available:
 - `bugfix` (bug fix) => PR's with this label must have a corresponding issue
 - `enhancement` (existing feature)
@@ -65,6 +62,41 @@ Each PR MUST have at least one label. The following labels are available:
 
 
 ## 4. Code Guidelines
+
+### 4.1 PEP8
+
+Please follow the PEP8 style guide. To do so, please use the [black](https://pypi.org/project/black/) python formatter.
+(All code in this repository is formatted using black)
+
+### 4.2 Documentation
+
+#### 4.2.1 Docstrings
+Please include docstrings for all functions and classes. These do not have to be long,
+but at least include the basic information (what the function does, what the parameters are, what the return value is, etc).
+
+#### 4.2.2 Comments
+Please include comments where necessary. This includes:
+- Comments explaining complex code
+- Comments explaining why you did something a certain way
+
+#### 4.2.3 Type Hints
+Please include type hints for all functions and classes.
+
+### 4.3 Complexity
+
+Please keep your code as simple as possible. We prefer longer, simpler code over shorter, more complex code.
+Avoid long list comprehensions, complex lambda functions, etc.
+
+### 4.4 Imports
+
+Please keep your imports as simple as possible. Avoid importing entire modules, and avoid importing multiple modules on one line.
+
+[!IMPORTANT]
+If you wish to use an external library, please ask first. We want to keep the number of external libraries to a minimum.
+(using external libraries already included in the requirements.txt is fine).
+
+[!WARNING]
+@skagame must review external libraries for security vulnerabilities before they can be used.
 
 
 ## 5. Reviewing Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,21 +8,21 @@ This document outlines the process for contributing to the project. Please read 
 
 If you are not listed as a contributor, you are still welcome to help out!
 Please fork the repository and make a pull request with your changes.
-Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
+Follow the guidelines below to ensure your pull request is correct. Incorrect pull requests will be rejected.
 
 ## 2. Contributors
 
 Please create your own branch and make a pull request to the master branch.
-Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
+Follow the guidelines below to ensure your pull request is correct. Incorrect pull requests will be rejected.
 
-## 3. PR Guidelines
+## 3. Pull Request Guidelines
 
 ### 3.1 Branch Names
 
 Please name your branch as follows:
 `<your-name>.<feature-name>`
 
-### 3.2 Commit Messages/ commits
+### 3.2 Commit Messages/ Commits
 
 - Use the present tense ("Add feature" not "Added feature")
 - Keep messages short and concise
@@ -134,8 +134,8 @@ For each type of PR, the following amount of code owners must approve the PR bef
 - `documentation` => 1
 - `dependencies` => 1 + @sebastiaan-daniels
 - `bugfix` => 2
+- `refactor` => 2
 - `enhancement` => 3
-- `refactor` => 3
 - `feature` => 4
 
 #### 5.2.4 Accepted code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,57 @@ Follow the guidelines below to ensure your pull request correct. Incorrect pull 
 Please create your own branch and make a pull request to the master branch.
 Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
 
-## Guidelines
+## PR Guidelines
 
 ### Branch Names
 
 Please name your branch as follows:
 `<your-name>.<feature-name>`
 
+### Commit Messages/ commits
+
+- Use the present tense ("Add feature" not "Added feature")
+- Keep messages short and concise
+- Keep commits small and concise (commit regularly)
+
+### Pull Requests
+
+#### Title
+
+Your title should be short and concise. It should be in the format:
+`<type>: <desc>`
+where `<type>` is one of the following:
+- `feat` (feature)
+- `fix` (bug fix)
+- `docs` (documentation)
+- `style` (formatting, missing semi colons, etc; no code change)
+- `refactor` (refactoring production code)
+- `test` (adding missing tests, refactoring tests; no production code change)
+- `chore` (updating grunt tasks etc; no production code change)
+
+and `<desc>` is a short description of the changes made.
+
+#### Description
+
+Your description is where you can go into more detail about your changes.
+Please include _at least_ the following:
+- What you changed
+- Why you changed it
+
+If your PR is related to an issue, please include the issue number in the description.
+If it solves the issue, please include `Closes #<issue-number>` in the description. This will automatically close the issue when the PR is merged.
+
+#### Labels
+
+Each PR MUST have at least one label. The following labels are available:
+- `bugfix` (bug fix) => PR's with this label must have a corresponding issue
+- `enhancement` (existing feature)
+- `documentation` (documentation)
+- `dependencies` (Updates a dependency) 
+- `feature` (new feature) 
+- `hotfix` (very small bugfix/typo fix)
+
+(PR's with no label will be rejected)
+
+
+## Code Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,3 +145,14 @@ If the required number of code owners have approved the PR, the PR may be merged
 If any code owner requests changes, (regardless whether or not the required number of code owners have approved the PR), the PR may not be merged until those changes have been either made or discussed and agreed upon.
 
 The code owner that requested changes must re-review the PR and approve it before it can be merged.
+
+### 5.3 PR's from code owners
+
+#### 5.3.1 General
+If a code owner makes a PR, the same rules apply as for any other contributor. The PR must be reviewed by the required number of code owners, and may not be merged until the required number of code owners have approved the PR.
+
+#### 5.3.2 Special cases
+
+Since a user cannot review their own PR, there are some cases in which more code owners must review the PR than there are existing.
+In these cases, if all code owners have approved the PR, the PR may be merged by any code owner.
+I.e if a code owner creates a feature, only 3 code owners must add a review. (since there are only 4 owners.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Pax-Academia
 
-Pax Academia is an open source project, and we welcome contributions of all kinds from anyone. As this project has grown to become a large project, we have had to implement some guidelines to ensure that the project remains maintainable and that contributions are of high quality, since this bot is used by well over 150.000 people.
+Pax Academia is an open source project, and we welcome contributions of all kinds from anyone. As this project has grown to become a large project, we have implemented some guidelines to ensure that the project remains maintainable and that contributions are of high quality.
 
 This document outlines the process for contributing to the project. Please read it carefully before making a contribution so that you know what to expect and what is expected of you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,32 @@
 # Contributing to Pax-Academia
 
-## Non Contributors
+## 1. Non Contributors
 
 If you are not listed as a contributor, you are still welcome to help out!
 Please fork the repository and make a pull request with your changes.
 Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
 
-## Contributors
+## 2. Contributors
 
 Please create your own branch and make a pull request to the master branch.
 Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
 
-## PR Guidelines
+## 3. PR Guidelines
 
-### Branch Names
+### 3.1 Branch Names
 
 Please name your branch as follows:
 `<your-name>.<feature-name>`
 
-### Commit Messages/ commits
+### 3.2 Commit Messages/ commits
 
 - Use the present tense ("Add feature" not "Added feature")
 - Keep messages short and concise
 - Keep commits small and concise (commit regularly)
 
-### Pull Requests
+### 3.3 Pull Requests
 
-#### Title
+#### 3.3.1 Title
 
 Your title should be short and concise. It should be in the format:
 `<type>: <desc>`
@@ -41,7 +41,7 @@ where `<type>` is one of the following:
 
 and `<desc>` is a short description of the changes made.
 
-#### Description
+#### 3.3.2 Description
 
 Your description is where you can go into more detail about your changes.
 Please include _at least_ the following:
@@ -51,7 +51,7 @@ Please include _at least_ the following:
 If your PR is related to an issue, please include the issue number in the description.
 If it solves the issue, please include `Closes #<issue-number>` in the description. This will automatically close the issue when the PR is merged.
 
-#### Labels
+#### 3.3.3 Labels
 
 Each PR MUST have at least one label. The following labels are available:
 - `bugfix` (bug fix) => PR's with this label must have a corresponding issue
@@ -64,4 +64,7 @@ Each PR MUST have at least one label. The following labels are available:
 (PR's with no label will be rejected)
 
 
-## Code Guidelines
+## 4. Code Guidelines
+
+
+## 5. Reviewing Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to Pax-Academia
 
+Pax Academia is an open source project, and we welcome contributions of all kinds from anyone. As this project has grown to become a large project, we have had to implement some guidelines to ensure that the project remains maintainable and that contributions are of high quality, since this bot is used by well over 150.000 people.
+
+This document outlines the process for contributing to the project. Please read it carefully before making a contribution so that you know what to expect and what is expected of you.
+
 ## 1. Non Contributors
 
 If you are not listed as a contributor, you are still welcome to help out!
@@ -57,8 +61,17 @@ Each PR MUST have at least one label. The following labels are available:
 - `dependencies` (Updates a dependency) 
 - `feature` (new feature) 
 - `hotfix` (very small bugfix/typo fix)
+- `refactor` (refactoring production code)
 
 (PR's with no label will be rejected)
+
+#### 3.3.4 Content
+A PR may not contain code and commits not related to the issue it is solving or feature it is completing.
+F.ex. 
+- a PR solving issue #1 may not contain code or commits related to issue #2.
+- Do not include a commit that changes something in the docs when working on a discord command (unless the docs are related to the command)
+- Do not refacter code in cog A when working on cog B
+- ...
 
 
 ## 4. Code Guidelines
@@ -96,7 +109,39 @@ If you wish to use an external library, please ask first. We want to keep the nu
 (using external libraries already included in the requirements.txt is fine).
 
 [!WARNING]
-@skagame must review external libraries for security vulnerabilities before they can be used.
+@sebastiaan-daniels must review external libraries for security vulnerabilities before they can be used.
 
 
 ## 5. Reviewing Guidelines
+
+### 5.1 Code Reviews from contributors
+
+Each contributor, regardless of their role, is allowed to review code.
+However, requested changes or comments made by contributors do not have to be followed by the author of the PR. They are merely suggestions.
+
+### 5.2 Code Reviews from maintainers (Code Owners)
+
+#### 5.2.1 General
+Each PR, depending on its complexity, must be reviewed by at least n maintainers. (see 5.2.3 for the number of maintainers required for each type of PR)
+No code may be merged without the approval of those code owners. All code owners must be requested to review the PR. (this should be done automatically by github)
+
+#### 5.2.2 Code Owners
+The project maintainers (owners), are the people listed under `.github/CODEOWNERS`.
+
+#### 5.2.3 Reviewing
+For each type of PR, the following amount of code owners must approve the PR before merging:
+- `hotfix` => 1
+- `documentation` => 1
+- `dependencies` => 1 + @sebastiaan-daniels
+- `bugfix` => 2
+- `enhancement` => 3
+- `refactor` => 3
+- `feature` => 4
+
+#### 5.2.4 Accepted code
+If the required number of code owners have approved the PR, the PR may be merged by any code owner.
+
+#### 5.2.5 Changes requested by a code owner
+If any code owner requests changes, (regardless whether or not the required number of code owners have approved the PR), the PR may not be merged until those changes have been either made or discussed and agreed upon.
+
+The code owner that requested changes must re-review the PR and approve it before it can be merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,12 +104,12 @@ Avoid long list comprehensions, complex lambda functions, etc.
 
 Please keep your imports as simple as possible. Avoid importing entire modules, and avoid importing multiple modules on one line.
 
-[!IMPORTANT]
-If you wish to use an external library, please ask first. We want to keep the number of external libraries to a minimum.
+> [!IMPORTANT]
+> If you wish to use an external library, please ask first. We want to keep the number of external libraries to a minimum.
 (using external libraries already included in the requirements.txt is fine).
 
-[!WARNING]
-@sebastiaan-daniels must review external libraries for security vulnerabilities before they can be used.
+> [!WARNING]
+> @sebastiaan-daniels must review external libraries for security vulnerabilities before they can be used.
 
 
 ## 5. Reviewing Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to Pax-Academia
+
+## Non Contributors
+
+If you are not listed as a contributor, you are still welcome to help out!
+Please fork the repository and make a pull request with your changes.
+Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
+
+## Contributors
+
+Please create your own branch and make a pull request to the master branch.
+Follow the guidelines below to ensure your pull request correct. Incorrect pull requests will be rejected.
+
+## Guidelines
+
+### Branch Names
+
+Please name your branch as follows:
+`<your-name>.<feature-name>`
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ A PR may not contain code and commits not related to the issue it is solving or 
 F.ex. 
 - a PR solving issue #1 may not contain code or commits related to issue #2.
 - Do not include a commit that changes something in the docs when working on a discord command (unless the docs are related to the command)
-- Do not refacter code in cog A when working on cog B
+- Do not refactor code in cog A when working on cog B
 - ...
 
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ General purpose utility bot for the Homework Help Discord server
 
 ## How to Contribute
 
-1. Fork this repository into your own account.
-   - Check out the [cogs](./cogs/README.md) folder for in progress cogs that you can contribute to.
-   - Check out [this](./ENVIRONMENT.md) on setting up the environment.
-2. Commit changes to your fork.
-3. Open a pull request, making sure to comapre across forks.
-   - For more information regarding pull requests across forks, please check out GitHub's official docs [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+To contribute to this project, please read the [Contributing Guidelines](./CONTRIBUTING.md).
 
 ## Running bot
 


### PR DESCRIPTION
Pax Academia started out as a small bot on the HwH discord server to fill in some gaps where small features were missing.
Today, it is a complex project with an entire team working on it, serving more than 150 thousand users daily*.

At the moment, we have a group of code owners which each need to accept every pull request. Which is good for security, but bad for speed. Some dependencies and bugfixes simply need to be implemented faster, as our production deployment needs to be up to date and correct.

This new document aims to outline new guidelines and rules for contributing to this project. Focusing heavily on creating good, complete PRs which can be implemented quickly for smaller fixes, and thoroughly reviewed for bigger feats.

I highly recommend carefully reviewing this proposal, and sending your comments here on github instead of discord to keep discussion of this proposal (and potential implementation) grouped.

@\collaborators: Please do not add commits to this PR, use the comments/request changes instead.

- Requires #233 
- * No clue how many actually, just took the number of server members.