### PR TITLE
fix: auto-delete survey messages

### DIFF
--- a/cogs/surveys.py
+++ b/cogs/surveys.py
@@ -23,7 +23,6 @@ SURVEY_SITES = [
 class Surveys(commands.Cog):
     # maps (channel id, message id) -> message
     # for all "survey detected" messages sent in the last hour
-    # (useful so that we can delete the tip if they fix their message)
     survey_detected_messages: ClassVar[dict[tuple[int, int], discord.Message]] = {}
 
     def __init__(self, bot: commands.Bot) -> None:

--- a/cogs/surveys.py
+++ b/cogs/surveys.py
@@ -71,10 +71,10 @@ class Surveys(commands.Cog):
         ).build()
 
         survey_detected_message = None
-        with suppress(discord.errors.Forbidden):
-            survey_detected_message = await message.channel.send(
-                content=f"<@{message.author.id}>",
+        with suppress(discord.errors.Forbidden, discord.errors.NotFound):
+            survey_detected_message = await message.reply(
                 embed=embed,
+                mention_author=True,
             )
 
         channel_name = getattr(message.channel, "name", f"<#{message.channel.id}>")


### PR DESCRIPTION
Broken replies are annoying! This PR deletes the "Survey Detected" message once the user deletes their message containing a survey (up to one hour after they send it, after which the cache is purged). (discord discussion: [link](https://discord.com/channels/238956364729155585/1040360228388098159/1163828958740094976))

![Discord_HBh0LZC1xN](https://github.com/danparizher/Pax-Academia/assets/44247924/1c6bd917-042d-4ed6-b22f-579055e28726)
