### PR TITLE
bugfix: missing return statement in `tips`

### DIFF
--- a/cogs/tips.py
+++ b/cogs/tips.py
@@ -72,7 +72,7 @@ async def send_tip(
     if isinstance(ctx, ApplicationContext):
         if anonymous.casefold() == "yes":
             await ctx.send(message_content, embed=embed)
-            await ctx.respond(
+            return await ctx.respond(
                 "Thanks for the tip! It was sent anonymously.",
                 ephemeral=True,
                 delete_after=5,


### PR DESCRIPTION
When a user sends an anonymous tip, the bot sends the same tip twice due to a missing return statement. This PR adds this statement.
- closes #269 