### PR TITLE
fix: Edge case where message has no content throws error

### DIFF
--- a/code_detection/base.py
+++ b/code_detection/base.py
@@ -129,6 +129,9 @@ class DetectorBase(ABC):
         Simply classifies each line of the text without applying any section-size limits.
         """
         lines = self.text.splitlines()
+        if not lines:
+            return []
+
         sections: list[DetectedSection] = []
 
         # special case for first line


### PR DESCRIPTION
The error:
```
Ignoring exception in on_message
Traceback (most recent call last):
  File "C:\Production code\Pax-Academia\venv\Lib\site-packages\discord\client.py", line 378, in _run_event
    await coro(*args, **kwargs)
  File "C:\Production code\Pax-Academia\cogs\detect_code.py", line 105, in on_message
    if autoformat and (detection_result := code_detection.detect(message.content)):
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Production code\Pax-Academia\code_detection\__init__.py", line 23, in detect
    best_match = max(
                 ^^^^
  File "C:\Production code\Pax-Academia\code_detection\__init__.py", line 25, in <lambda>
    key=lambda d: (d.probable_lines_of_code, d.lines_of_code),
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Production code\Pax-Academia\code_detection\base.py", line 472, in probable_lines_of_code
    for section in self.detect()
                   ^^^^^^^^^^^^^
  File "C:\Production code\Pax-Academia\code_detection\base.py", line 454, in detect
    self._cached_detection_result = tuple(self.detect_uncached())
                                          ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Production code\Pax-Academia\code_detection\base.py", line 445, in detect_uncached
    self.merge_short_sections(self.classify_lines()),
                              ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Production code\Pax-Academia\code_detection\base.py", line 135, in classify_lines
    line = lines.pop(0)
           ^^^^^^^^^^^^
IndexError: pop from empty list
```