### PR TITLE
Bugfix: Add base branch to pull request

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -47,3 +47,4 @@ jobs:
           title: "Update requirements.txt"
           body: "This PR updates the requirements.txt file."
           branch: "update-requirements"
+          base: "main"


### PR DESCRIPTION
This PR adds the base branch parameter to the pull request, which fixes the following build error:

`The 'base' and 'branch' for a pull request must be different branches. Unable to continue.`