### PR TITLE
Bugfix: /ping correctly shows whether the bot is up to date or not

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -58,6 +58,7 @@ def get_git_revision_short_hash() -> str:
 
 
 def get_origin_revision_short_hash() -> str:
+    subprocess.check_call(["git", "fetch", "origin"])
     return (
         subprocess.check_output(["git", "rev-parse", "--short", "origin/main"])
         .decode("ascii")


### PR DESCRIPTION
This PR fixes (I think?) the issue where the bot does not fetch the origin when displaying whether it is up to date or not.

- closes #277 
