### PR TITLE
bugfix: pull from source

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -37,6 +37,7 @@ jobs:
             echo "No changes in requirements.txt"
           else
             git commit -m "Update requirements.txt"
+            git pull --rebase origin update-requirements
             git push --set-upstream origin update-requirements
           fi
 


### PR DESCRIPTION
Fixes:

```
Run git checkout -b update-requirements
Switched to a new branch 'update-requirements'
[update-requirements 6a47132] Update requirements.txt
 1 file changed, 4 insertions(+), 4 deletions(-)
To https://github.com/danparizher/Pax-Academia
 ! [rejected]        update-requirements -> update-requirements (fetch first)
error: failed to push some refs to 'https://github.com/danparizher/Pax-Academia'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```