### PR TITLE
enhancement: Delete all multiposts (rather than just after the third posting)

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -58,9 +58,11 @@ class MessageFingerprint:
             message_id=message.id,
             jump_url=message.jump_url,
             attachment_urls=[attachment.url for attachment in message.attachments],
-            content_hash=cls.sha256_hash(filtered_content)
-            if filtered_content is not None
-            else None,
+            content_hash=(
+                cls.sha256_hash(filtered_content)
+                if filtered_content is not None
+                else None
+            ),
         )
 
     # performs a SHA256 hash
@@ -248,8 +250,7 @@ class Moderation(commands.Cog):
     # this function should be called after every on_message
     # it will detect multiposts and will apply the following moderation:
     #   - Original Message - No action taken
-    #   - Second Message - React to both the original and second message with a custom emoji, and warn the author under the second message
-    #   - Third and Subsequent Messages - Delete the message and warn the author, then delete the warning after 15 seconds
+    #   - Subsequent Messages - Delete the message and warn the author, then delete the warning after 15 seconds
     # A message is a "multipost" if it meets these criteria:
     #   - Author is not a bot
     #   - Author doesn't have the ALLOW_MULTIPOST_FOR_ROLE role
@@ -285,82 +286,40 @@ class Moderation(commands.Cog):
         if n_previous_messages == 0:
             return
 
-        # First Multipost - React to the original message with a custom multipost emoji, and reply with a warning to the multipost
-        if n_previous_messages == 1:
-            original_message = previous_messages[0]
+        # We used to have different behavior depending on `n_previous_messages`
+        # but now we just delete all multiposts. I'm keeping the variable around
+        # just because it would require a lot of code changes to remove it.
+        first_message, *_other_messages = previous_messages
 
-            embed = EmbedBuilder(
-                title="Multi-Post Warning",
-                description="Please don't send the same message in multiple channels.",
-                fields=[
-                    (
-                        "Original Message",
-                        f"[link]({original_message.jump_url})",
-                        True,
-                    ),
-                ],
-            ).build()
+        embed = EmbedBuilder(
+            title="Multi-Post Deleted",
+            description="Please don't send the same message in multiple channels. Your message has been deleted.\n\nThis warning will be deleted in 15 seconds.",
+            fields=[
+                (
+                    "Original Message",
+                    f"[link]({first_message.jump_url})",
+                    True,
+                ),
+            ],
+        ).build()
 
-            try:
-                await self.bot.http.add_reaction(
-                    original_message.channel_id,
-                    original_message.message_id,
-                    MULTIPOST_EMOJI,
-                )
-                await message.add_reaction(MULTIPOST_EMOJI)
-
-                warning = await message.reply(embed=embed)
-                await self.delete_previous_multipost_warnings(
-                    fingerprint.channel_id,
-                    fingerprint.author_id,
-                )
-                self.multipost_warnings[message.id] = (warning, fingerprint)
-                log(f"First mp warning for $ in {message.channel.name}", message.author)
-            except discord.errors.HTTPException as e:
-                if "unknown message".casefold() in repr(e).casefold():
-                    # The multipost has already been deleted, take no action
-                    return
-                # unknown error, just raise it
-                raise
-
-        # Subsequent Multiposts - Reply with a warning (and ping the offender), delete the multipost, then delete the warning after 15 seconds
-        else:
-            first_message, second_message, *_other_messages = previous_messages
-
-            embed = EmbedBuilder(
-                title="Multi-Post Deleted",
-                description="Please don't send the same message in multiple channels. Your message has been deleted.",
-                fields=[
-                    (
-                        "First Message",
-                        f"[link]({first_message.jump_url})",
-                        True,
-                    ),
-                    (
-                        "Second Message",
-                        f"[link]({second_message.jump_url})",
-                        True,
-                    ),
-                ],
-            ).build()
-
-            try:
-                await message.reply(
-                    message.author.mention,
-                    embed=embed,
-                    delete_after=15,
-                )
-                await message.delete()
-                log(
-                    f"Subsequent mp warning for $ in {message.channel.name}",
-                    message.author,
-                )
-            except discord.errors.HTTPException as e:
-                if "unknown message".casefold() in repr(e).casefold():
-                    # The multiposted message has already been deleted, take no action
-                    return
-                # unknown error, just raise it
-                raise
+        try:
+            await message.reply(
+                message.author.mention,
+                embed=embed,
+                delete_after=15,
+            )
+            await message.delete()
+            log(
+                f"Subsequent mp warning for $ in {message.channel.name}",
+                message.author,
+            )
+        except discord.errors.HTTPException as e:
+            if "unknown message".casefold() in repr(e).casefold():
+                # The multiposted message has already been deleted, take no action
+                return
+            # unknown error, just raise it
+            raise
 
     @commands.Cog.listener()
     async def on_message(self: Moderation, message: discord.Message) -> None:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -279,13 +279,13 @@ class Moderation(commands.Cog):
         ):
             return
 
-        previous_messages = await self.record_fingerprint(message)
+        previous_postings = await self.record_fingerprint(message)
 
-        if not previous_messages:
+        if not previous_postings:
             # This is a new, unique message. Not a multipost.
             return
 
-        first_post = previous_messages[0]
+        first_post = previous_postings[0]
 
         embed = EmbedBuilder(
             title="Multi-Post Deleted",

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -188,7 +188,7 @@ class Moderation(commands.Cog):
         fingerprint = MessageFingerprint.build(message)
         self.fingerprints.append(fingerprint)
 
-        multipost_of = [
+        return [
             other_fingerprint
             for other_fingerprint in self.fingerprints
             if (
@@ -196,8 +196,6 @@ class Moderation(commands.Cog):
                 and await fingerprint.is_multipost_of(other_fingerprint)
             )
         ]
-
-        return multipost_of
 
     # deletes recorded fingerprints after 2 minutes,
     # and clears out logged `multipost_warnings` after 10 minutes


### PR DESCRIPTION
- Current behavior: send a warning about the second post, delete the third and subsequent postings
- Proposed behavior: delete the second and subsequent postings

"public" discussion: https://discord.com/channels/238956364729155585/892125731600101406/1256106776986652693
contributor discussion: https://discord.com/channels/238956364729155585/1040360228388098159/1256324629723877487