### PR TITLE
enhancement: Extend multipost detection to 10 minutes

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -250,7 +250,12 @@ class Moderation(commands.Cog):
 
         embed = EmbedBuilder(
             title="Multi-Post Deleted",
-            description="Please don't send the same message in multiple channels. Your message has been deleted.\n\nThis warning will be deleted in 15 seconds.",
+            description=(
+                "Please don't send the same message in multiple channels."
+                " Your message has been deleted."
+                " You may delete your original message to re-post it elsewhere."
+                " \n\nThis warning will be deleted in 15 seconds."
+            ),
             fields=[
                 (
                     "Original Message",
@@ -287,6 +292,7 @@ class Moderation(commands.Cog):
         self: Moderation,
         payload: discord.RawMessageDeleteEvent,
     ) -> None:
+        # You're allowed to re-post messages that have been deleted.
         for i, fingerprint in enumerate(self.fingerprints):
             if payload.message_id == fingerprint.message_id:
                 del self.fingerprints[i]

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -23,7 +23,7 @@ MULTIPOST_EMOJI = os.getenv("MULTIPOST_EMOJI", ":regional_indicator_m:")
 ALLOW_MULTIPOST_FOR_ROLE = os.getenv("ALLOW_MULTIPOST_FOR_ROLE")
 
 # how long must you wait before being allowed to multipost
-ACCEPTABLE_MULTIPOST_DELAY = 15
+ACCEPTABLE_MULTIPOST_DELAY = 600
 
 
 @dataclass

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -88,10 +88,9 @@ class MessageFingerprint:
         # remove all punctuation and spacing
         content = content.translate(
             str.maketrans(
-                dict.fromkeys(
-                    string.whitespace + string.punctuation + string.digits,
-                    "",
-                ),
+                "",
+                "",
+                string.whitespace + string.punctuation + string.digits,
             ),
         )
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -196,7 +196,7 @@ class Moderation(commands.Cog):
         ]
 
     # deletes recorded fingerprints after {ACCEPTABLE_MULTIPOST_DELAY} seconds
-    @tasks.loop(seconds=3)
+    @tasks.loop(seconds=15)
     async def clear_old_cached_data(self) -> None:
         n_fingerprints_to_delete = bisect.bisect_right(
             [fp.created_at for fp in self.fingerprints],


### PR DESCRIPTION
Current behavior: deletes duplicate posts up to 120 seconds after the original post
Proposed behavior: 600 seconds

also:
- deletes some unused methods & variables that should have been removed in #295 
- uses `bisect` instead of linear search (more prevalent optimization since we will be storing 5x as much content)

relevant discussion: https://discord.com/channels/238956364729155585/892125731600101406/1260518966519136267