### PR TITLE
enhancement: Alert on message edits, too

### DIFF
--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -390,7 +390,8 @@ class Alerts(commands.Cog):
                 title="Alert",
                 description=(
                     f"Your {'keyword' if len(keywords) == 1 else 'keywords'} "
-                    f"{', '.join([f'`{keyword}`' for keyword in keywords])} was mentioned "
+                    f"{', '.join([f'`{keyword}`' for keyword in keywords])} "
+                    f"{'was' if len(keywords) == 1 else 'were'} mentioned "
                     f"in {message.channel.mention} by {message.author.mention}."
                 ),
                 fields=[

--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -341,6 +341,26 @@ class Alerts(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self: Alerts, message: discord.Message) -> None:
+        await self.maybe_send_alerts(message)
+
+    @commands.Cog.listener()
+    async def on_raw_message_edit(
+        self: Alerts,
+        payload: discord.RawMessageUpdateEvent,
+    ) -> None:
+        channel = self.bot.get_channel(
+            payload.channel_id,
+        ) or await self.bot.fetch_channel(
+            payload.channel_id,
+        )
+
+        assert isinstance(
+            channel,
+            discord.abc.Messageable,
+        ), "Presumably a channel that has messages in it should be 'messageable'."
+
+        message = await channel.fetch_message(payload.message_id)
+        await self.maybe_send_alerts(message)
 
 
 def setup(bot: commands.Bot) -> None:

--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -395,7 +395,7 @@ class Alerts(commands.Cog):
     async def maybe_send_alerts(self: Alerts, message: discord.Message) -> None:
         """
         If the message is valid and contains keyword(s),
-        send DM(s) to the user(s) who added the keyword(s)
+        send a DM to the user(s) who added the keyword(s)
         """
 
         # never alert on bot messages
@@ -421,7 +421,6 @@ class Alerts(commands.Cog):
         )
 
         # group together alerts by the person who is to be alerted
-        # (so that we don't alert someone multiple times for the same message)
         alerts: dict[int, list[str]] = {}
         for keyword, uid in c.fetchall():
             if not re.search(keyword, message.content, re.IGNORECASE):
@@ -465,7 +464,7 @@ class Alerts(commands.Cog):
                     member,
                     message.id,
                     frozenset(keywords),
-                )
+                ),
             )
 
         await asyncio.gather(*sending_alerts)

--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -67,7 +67,10 @@ class AlertRecord:
     def __hash__(self) -> int:
         return hash((self.message_id, self.alerted_user_id))
 
-    def __eq__(self, other: AlertRecord) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AlertRecord):
+            raise NotImplementedError
+
         return (
             self.message_id == other.message_id
             and self.alerted_user_id == other.alerted_user_id

--- a/cogs/dictionary.py
+++ b/cogs/dictionary.py
@@ -113,9 +113,9 @@ class SimilarWord:
         :return: a WordInformation
         """
         status_code, soup = await fetch_page_cached(self.url)
-        assert (
-            status_code == 200
-        ), "Got a non-200 response while fetching a URL that was provided directly from Oxford."
+        assert status_code == 200, (
+            "Got a non-200 response while fetching a URL that was provided directly from Oxford."
+        )
         return parse_oxford_definition_page(self.url, soup)
 
 
@@ -187,9 +187,9 @@ class WordInformation:
                 footer=footer,
             ).build()
 
-        assert (
-            len(self.senses) > 1
-        ), "It shouldn't be possible for a WordInformation to be created without a sense."
+        assert len(self.senses) > 1, (
+            "It shouldn't be possible for a WordInformation to be created without a sense."
+        )
 
         sense_parts = []
         for index, sense in enumerate(self.senses[:5]):

--- a/cogs/staffapps_backend.py
+++ b/cogs/staffapps_backend.py
@@ -694,9 +694,9 @@ class staffAppsMain(discord.ui.View):
         button: discord.ui.Button,
         interaction: discord.Interaction,
     ) -> None:
-        assert (
-            interaction.user is not None
-        ), "Our Discord server must be haunted! Every interaction must be paired with a user."
+        assert interaction.user is not None, (
+            "Our Discord server must be haunted! Every interaction must be paired with a user."
+        )
 
         self.db = database.connect()
         self.cursor = self.db.cursor()
@@ -745,9 +745,9 @@ class staffAppsMain(discord.ui.View):
         button: discord.ui.Button,
         interaction: discord.Interaction,
     ) -> None:
-        assert (
-            interaction.user is not None
-        ), "Our Discord server must be haunted! Every interaction must be paired with a user."
+        assert interaction.user is not None, (
+            "Our Discord server must be haunted! Every interaction must be paired with a user."
+        )
 
         self.db = database.connect()
         self.cursor = self.db.cursor()

--- a/message_formatting/embeds.py
+++ b/message_formatting/embeds.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 import discord
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class EmbedBuilder:

--- a/util/limiter.py
+++ b/util/limiter.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import functools
 from os import getenv
-from typing import Awaitable, Callable, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar
 
 from discord import ApplicationContext
 
 import database
 from message_formatting.embeds import EmbedBuilder
 from util.logger import log
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 LimitedCommandParams = ParamSpec("LimitedCommandParams")
 LimitedCommandReturnValue = TypeVar("LimitedCommandReturnValue")


### PR DESCRIPTION
Implements #301

Currently, we only alert on initial messages but do not consider when keywords are edited in after-the-fact.

This PR adds functionality to keep track of every alert we send. When a message is edited, we scan it for keywords and compare those keywords to the keywords in the alerts we have already sent. If there are new keywords present, which haven't been alerted on yet, we will send a new alert.

We only keep track of alerts for 6 hours, since it is impractical to store this data indefinitely and nearly 100% of message edits take place within the first few minutes anyway. This does mean that a user may be alerted more than once about a message with the same keywords if it is edited after 6 hours, although this will be exceedingly rare.

Demo:

https://github.com/user-attachments/assets/b9426ace-c090-4ded-802c-0eb381c43dcc


https://github.com/user-attachments/assets/785817ee-9582-45a6-a2bf-3a56cfe481c2

