### PR TITLE
Feat: Add automatic :swaghi: reactions to #introductions channel

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -189,7 +189,7 @@ class Misc(commands.Cog):
         """
         introductionsChannelID: int = 769639145764159488
         if message.channel.id == introductionsChannelID:
-            await message.add_reaction(emoji = "<:swaghi:721519806930485288>")
+            await message.add_reaction(emoji="<:swaghi:721519806930485288>")
 
     @VIEW_LOGS_PERMISSIONS
     @commands.slash_command(

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -179,6 +179,18 @@ class Misc(commands.Cog):
 
         await edit(f"{COMPLETED_EMOJI} Presented {len(tables)} table(s).")
 
+    @commands.Cog.listener()
+    async def on_message(self: Misc, message: discord.Message) -> None:
+        """
+        It adds the :swaghi: reaction to a message if it's in the #introductions channel.
+
+        :param message: The message that was sent.
+        :type message: discord.Message
+        """
+        introductionsChannelID: int = 769639145764159488
+        if message.channel.id == introductionsChannelID:
+            await message.add_reaction(emoji = "<:swaghi:721519806930485288>")
+
     @VIEW_LOGS_PERMISSIONS
     @commands.slash_command(
         name="view-logs",


### PR DESCRIPTION
This method adds the `swaghi:` introduction in the `#introductions` channel. I initially thought of this as a joke, but it seems pretty popular.